### PR TITLE
Feat/edit clipboard #2

### DIFF
--- a/clip.cpp
+++ b/clip.cpp
@@ -19,6 +19,10 @@ bool Clip::isUrlValid(QString url) {
 	return urlPattern.match(url).hasMatch();
 }
 
+void Clip::reprocessClipboardContent() {
+	onDataChanged();
+}
+
 /* CLIPBOARD METHODS */
 
 void Clip::clear() {
@@ -142,7 +146,7 @@ void Clip::onDataChanged() {
 		history.insert(index, image);
 		emit imageReceived(image);
 #ifdef QT_DEBUG
-		cout << "Clip> Received image = (" + QString::number(image.size().width()).toStdString() + "x" + QString::number(image.size().height()).toStdString() + ")" << endl;
+		cout << "Clip> Received image = (" << image.size().width() << "x" << image.size().height() << ")" << endl;
 #endif
 	}
 }

--- a/clip.h
+++ b/clip.h
@@ -17,6 +17,29 @@
 
 using namespace std;
 
+/**
+ * This is the clipboard manager for the application. It is extended from
+ * the class [`QClipboard`](https://doc.qt.io/qt-5/qclipboard.html). To use it, you must first
+ * get the unique instance of the class by calling `getInstance()`:
+ * 
+ * @code
+ * Clip* myClip = Clip::getInstance();
+ * @endcode
+ * 
+ * It implements all methods from [`QClipboard`](https://doc.qt.io/qt-5/qclipboard.html),
+ * except that the getters begin with the prefix `get` (e.g. `clipboard->text()` becomes
+ * `clip->getText()`).
+ * 
+ * One of the most interesting feature in this class compared to
+ * [`QClipboard`](https://doc.qt.io/qt-5/qclipboard.html) is the signals:
+ * Instead of having on signal with a [`QMimeData`](https://doc.qt.io/qt-5/qmimedata.html),
+ * the class emits a signal depending on the MIME Type (e.g. A text-flavored content will
+ * emit the signal `Clip::textReceived(QString)`).
+ * 
+ * Finally, it also save the history of the clipboard.
+ * @brief Clipboard manager. It implements the Singleton pattern design.
+ * @author Valentin Berger
+ */
 class Clip : public QObject
 {
 	Q_OBJECT
@@ -24,11 +47,31 @@ private:
 	Clip(QObject* parent = nullptr);
 	
 public:
+	/**
+	 * Get the unique instance of the class
+	 * @param parent The parent of the class. It is not mandatory to provide it.
+	 * @return Return the unique instance of the class. It is advised to store
+	 * it in a pointer if you will use it frequently.
+	 */
 	static Clip* getInstance(QObject* parent = nullptr);
 	
 	/* METHOD */
 	
+	/**
+	 * Check if the given string is a valid URL using regular expression.
+	 * @param url The url to test.
+	 * @return Return `true` is the given string is a valid url, `false` otherwise.
+	 */
 	static bool isUrlValid(QString url);
+	
+	/**
+	 * Reprocess the actual clipboard content without changing it. As a result, the
+	 * instance will call all corresponding signals according to the clipboard MIME Data.
+	 * It is usefull when the clipboard have been changed before that the instance has
+	 * been connected to slots, or at startup of the application to get the actual
+	 * clipboard content.
+	 */
+	void reprocessClipboardContent();
 	
 	/* CLIPBOARD METHODS */
 	

--- a/doxy.conf
+++ b/doxy.conf
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "My Project"
+PROJECT_NAME           = "Dragon's Drop"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -44,21 +44,21 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          =
+PROJECT_BRIEF          = "Dragon's Drop is an application that can synchronize your clipboard on multiple devices!"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           =
+PROJECT_LOGO           = "C:\Users\Valentin\Documents\QtProjects\DragonsDrop\res\dragonsdrop64.png"
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       =
+OUTPUT_DIRECTORY       = "doc"
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -457,25 +457,25 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PACKAGE        = NO
+EXTRACT_PACKAGE        = YES
 
 # If the EXTRACT_STATIC tag is set to YES, all static members of a file will be
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,
@@ -491,7 +491,7 @@ EXTRACT_LOCAL_CLASSES  = YES
 # included.
 # The default value is: NO.
 
-EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_LOCAL_METHODS  = YES
 
 # If this flag is set to YES, the members of anonymous namespaces will be
 # extracted and appear in the documentation as a namespace called
@@ -500,7 +500,7 @@ EXTRACT_LOCAL_METHODS  = NO
 # are hidden.
 # The default value is: NO.
 
-EXTRACT_ANON_NSPACES   = NO
+EXTRACT_ANON_NSPACES   = YES
 
 # If the HIDE_UNDOC_MEMBERS tag is set to YES, doxygen will hide all
 # undocumented members inside documented classes or files. If set to NO these
@@ -930,7 +930,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = "examples"
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -944,13 +944,13 @@ EXAMPLE_PATTERNS       = *
 # irrespective of the value of the RECURSIVE tag.
 # The default value is: NO.
 
-EXAMPLE_RECURSIVE      = NO
+EXAMPLE_RECURSIVE      = YES
 
 # The IMAGE_PATH tag can be used to specify one or more files or directories
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             =
+IMAGE_PATH             = "res"
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program
@@ -1711,7 +1711,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2278,7 +2278,7 @@ DIA_PATH               =
 # and usage relations if the target is undocumented or is not a class.
 # The default value is: YES.
 
-HIDE_UNDOC_RELATIONS   = YES
+HIDE_UNDOC_RELATIONS   = NO
 
 # If you set the HAVE_DOT tag to YES then doxygen will assume the dot tool is
 # available from the path. This tool is part of Graphviz (see:
@@ -2287,7 +2287,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of
@@ -2353,7 +2353,7 @@ GROUP_GRAPHS           = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-UML_LOOK               = NO
+UML_LOOK               = YES
 
 # If the UML_LOOK tag is enabled, the fields and methods are shown inside the
 # class node. If there are many fields or methods and many nodes the graph may
@@ -2366,7 +2366,7 @@ UML_LOOK               = NO
 # Minimum value: 0, maximum value: 100, default value: 10.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-UML_LIMIT_NUM_FIELDS   = 10
+UML_LIMIT_NUM_FIELDS   = 100
 
 # If the TEMPLATE_RELATIONS tag is set to YES then the inheritance and
 # collaboration graphs will show the relations between templates and their
@@ -2374,7 +2374,7 @@ UML_LIMIT_NUM_FIELDS   = 10
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-TEMPLATE_RELATIONS     = NO
+TEMPLATE_RELATIONS     = YES
 
 # If the INCLUDE_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are set to
 # YES then doxygen will generate a graph for each documented file showing the
@@ -2514,7 +2514,7 @@ PLANTUML_INCLUDE_PATH  =
 # Minimum value: 0, maximum value: 10000, default value: 50.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_GRAPH_MAX_NODES    = 50
+DOT_GRAPH_MAX_NODES    = 100
 
 # The MAX_DOT_GRAPH_DEPTH tag can be used to set the maximum depth of the graphs
 # generated by dot. A depth value of 3 means that only nodes reachable from the
@@ -2538,7 +2538,7 @@ MAX_DOT_GRAPH_DEPTH    = 0
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_TRANSPARENT        = NO
+DOT_TRANSPARENT        = YES
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -63,6 +63,52 @@ MainWindow::~MainWindow() {
 	delete ui;
 }
 
+void MainWindow::editClipboard(QString fileExtension, std::function<bool(QFile*)> write, std::function<bool(QFile*)> read) {
+	// See https://doc.qt.io/qt-5/qtemporarydir.html
+    //QTemporaryFile f(R::getTemporaryFileTemplate("txt"));
+	QTemporaryDir dir(R::getTemporaryDirTemplate());
+	QString path = dir.path() + (!dir.path().endsWith("/") ? "/" : "");
+	
+	if (!fileExtension.startsWith("."))
+		fileExtension = "." + fileExtension;
+	
+	if (dir.isValid()) {
+		// Create file
+		QFile f(path + "dragonsdrop" + QString::number(QDateTime::currentDateTime().toTime_t()) + fileExtension);
+		
+		if (!f.open(QIODevice::ReadWrite | QIODevice::Text))
+			QMessageBox::critical(this, tr("Error"), tr("An error occured while creating the temporary file."));
+		
+		// Write file
+		if (!write(&f))
+			return;
+		
+#ifdef QT_DEBUG
+		cout << QString("file://" + QString(f.fileName().startsWith("/") ? "" : "/") + f.fileName()).toStdString() << endl;
+#endif
+		// Open the app associated to the text files
+		QDesktopServices::openUrl("file://" + QString(f.fileName().startsWith("/") ? "" : "/") + f.fileName());
+		
+		// Display message box
+		QMessageBox box(this);
+		box.setIconPixmap(R::getDragonsDropIcon());
+		box.setWindowTitle(tr("Edit text..."));
+		box.setText(tr("Press 'Operation finished' when you finished the operation.", "The name of the button must also be translated"));
+		box.setStandardButtons(QMessageBox::Ok);
+		box.setButtonText(QMessageBox::Ok, tr("Operation finished"));
+		box.setModal(true);
+		box.exec();
+		
+		// Read file.
+		if (!read(&f))
+			return;
+		
+		f.close();
+	}
+	else
+		QMessageBox::critical(this, tr("Error"), tr("An error occured while creating the temporary directory."));
+}
+
 void MainWindow::addHistoryRow(QTableWidgetItem* k, QTableWidgetItem* v) {
 	ui->tw_history->setRowCount(ui->tw_history->rowCount()+1);
 	ui->tw_history->setItem(ui->tw_history->rowCount() - 1, 0, k);
@@ -86,7 +132,7 @@ void MainWindow::addHistoryRow(QColor value) {
 	consolas.setBold(true);
 	v->setFont(consolas);
 	v->setBackgroundColor(value);
-	if (value.lightness() < 180)
+	if (value.lightness() < 170)
 		v->setForeground(QBrush(Qt::white));
 	addHistoryRow(v);
 }
@@ -98,7 +144,7 @@ void MainWindow::addHistoryRow(QImage value) {
 	addHistoryRow(v);
 }
 
-void MainWindow::onDataChanged(const QMimeData* data) {
+void MainWindow::onDataChanged(const QMimeData*) {
 }
 
 void MainWindow::onTextReceived(QString text) {
@@ -138,44 +184,18 @@ void MainWindow::on_actionExit_triggered() {
 }
 
 void MainWindow::on_actionEdit_clipboard_as_text_triggered() {
-	// See https://doc.qt.io/qt-5/qtemporarydir.html
-    //QTemporaryFile f(R::getTemporaryFileTemplate("txt"));
-	QTemporaryDir dir(R::getTemporaryDirTemplate());
-	QString path = dir.path() + (!dir.path().endsWith("/") ? "/" : "");
-	
-	//if (f.open()) {
-	
-	if (dir.isValid()) {
-		// Create file
-		QFile f(path + "dragonsdrop" + QString::number(QDateTime::currentDateTime().toTime_t()) + ".txt");
-		
-		if (!f.open(QIODevice::ReadWrite | QIODevice::Text))
-			QMessageBox::critical(this, tr("Error"), tr("An error occured while creating the temporary file."));
-		
-		// Write file
-		QTextStream out(&f);
+	editClipboard(".txt",
+	[this](QFile* f) {
+		// Write
+		QTextStream out(f);
 		out << clip->getText() << endl;
 		out.flush();
-		
-#ifdef QT_DEBUG
-		cout << QString("file://" + QString(f.fileName().startsWith("/") ? "" : "/") + f.fileName()).toStdString() << endl;
-#endif
-		// Open the app associated to the text files
-		QDesktopServices::openUrl("file://" + QString(f.fileName().startsWith("/") ? "" : "/") + f.fileName());
-		
-		// Display message box
-		QMessageBox box(this);
-		box.setIconPixmap(R::getDragonsDropIcon());
-		box.setWindowTitle(tr("Edit text..."));
-		box.setText(tr("Press 'Operation finished' when you finished the operation.", "The name of the button must also be translated"));
-		box.setStandardButtons(QMessageBox::Ok);
-		box.setButtonText(QMessageBox::Ok, tr("Operation finished"));
-		box.setModal(true);
-		box.exec();
-		
-		// Read file.
+		return true;
+	},
+	[this](QFile* f) {
+		// Read
 		QString result = "";
-		QTextStream in(&f);
+		QTextStream in(f);
 		in.seek(0);
 		while (!in.atEnd())
 			result += in.readLine() + "\n";
@@ -187,19 +207,53 @@ void MainWindow::on_actionEdit_clipboard_as_text_triggered() {
 		cout << "Result: " << result.toStdString() << endl;
 #endif
 		clip->setText(result);
-		
-		f.close();
-	}
-	else
-		QMessageBox::critical(this, tr("Error"), tr("An error occured while creating the temporary directory."));
+		return true;
+	});
 }
 
 void MainWindow::on_actionEdit_clipboard_as_color_triggered() {
-    //
+	QColor* initialColor = nullptr;
+	if (QColor::isValidColor(clip->getText()))
+		initialColor = new QColor(clip->getText());
+	else
+		initialColor = new QColor(Qt::black);
+	
+	QColor newColor = QColorDialog::getColor(*initialColor, this, "Pick a new color", QColorDialog::ShowAlphaChannel);
+	
+	if (newColor.isValid())
+		clip->setText(newColor.name());
 }
 
 void MainWindow::on_actionEdit_clipboard_as_image_triggered() {
-    //
+	editClipboard(".png",
+	[this](QFile* f) {
+		// Write
+		if (clip->getImage().isNull()) {
+			QMessageBox::warning(this, "Error", "No image in the clipboard");
+			return false;
+		}
+		else {
+			//clip->getImage().save(f, "PNG");
+			clip->getPixmap().save(f, "PNG");
+			return true;
+		}
+	},
+	[this](QFile* f) {
+		// Read
+		
+		// Reset position carret
+		QTextStream in(f);
+		in.seek(0);
+		
+		// Load the image
+		QImage image(QFileInfo(*f).absoluteFilePath());
+		
+#ifdef QT_DEBUG
+		cout << "Result: " << image.size().width() << "x" << image.size().height() << endl;
+#endif
+		clip->setImage(image);
+		return true;
+	});
 }
 
 void MainWindow::on_actionAbout_Dragon_s_Drop_triggered() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -176,8 +176,13 @@ void MainWindow::on_actionEdit_clipboard_as_text_triggered() {
 		// Read file.
 		QString result = "";
 		QTextStream in(&f);
-		 while (!in.atEnd())
-			 result += in.readLine() + "\n";
+		in.seek(0);
+		while (!in.atEnd())
+			result += in.readLine() + "\n";
+		
+		// Remove last "\n"
+		if (result.endsWith("\n"))
+			result.remove(QRegularExpression("\\n$"));
 #ifdef QT_DEBUG
 		cout << "Result: " << result.toStdString() << endl;
 #endif

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -137,6 +137,32 @@ void MainWindow::on_actionExit_triggered() {
     qApp->exit();
 }
 
+void MainWindow::on_actionEdit_clipboard_as_text_triggered() {
+	// See https://doc.qt.io/qt-5/qtemporarydir.html
+    QTemporaryFile f(R::getTemporaryFileTemplate("txt"));
+	if (f.open()) {
+		//cout << QString("file://" + QString(f.fileName().startsWith("/") ? "" : "/") + f.fileName()).toStdString() << endl;
+		QDesktopServices::openUrl("file://" + QString(f.fileName().startsWith("/") ? "" : "/") + f.fileName());
+		QMessageBox box(this);
+		box.setIconPixmap(R::getDragonsDropIcon());
+		box.setWindowTitle(tr("Edit text..."));
+		box.setText(tr("Press 'Ok' when you finished the operation."));
+		box.setStandardButtons(QMessageBox::Ok);
+		box.setModal(true);
+		box.exec();
+		// TODO: Read file.
+		f.close();
+	}
+}
+
+void MainWindow::on_actionEdit_clipboard_as_color_triggered() {
+    //
+}
+
+void MainWindow::on_actionEdit_clipboard_as_image_triggered() {
+    //
+}
+
 void MainWindow::on_actionAbout_Dragon_s_Drop_triggered() {
     QMessageBox::about(this, ui->actionAbout_Dragon_s_Drop->text(),
 					   "<p><b>Dragon's Drop</b> is an application that can synchronize your clipboard on multiple devices! It is written in C++ with <a href='https://www.qt.io/'>Qt</a> Framework.</p>"

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -59,6 +59,8 @@ public:
 	 * @param fileExtension The file extension that can open the corresponding application.
 	 * @param write Function that write the clipboard content in the given `QFile`. This file object is already instanciated and open. Please do not close the file inside this function. Returns `true` by default, `false` if there is an exception and the method `editClipboard()` must stop right after the execution of `write()`.
 	 * @param read Function that read the given `QFile` content to the clipboard. This file object is already instanciated and open. Please do not close the file inside this function. Returns `true` by default, `false` if there is an exception and the method `editClipboard()` must stop right after the execution of `write()`.
+	 * @param writeFlags Specify the flags to open the temporary file for the writing process. By default, it is open with `QIODevice::WriteOnly | QIODevice::Text`.
+	 * @param readFlags Specify the flags to open the temporary file for the reading process. By default, it is open with `QIODevice::ReadOnly | QIODevice::Text`.
 	 */
 	void editClipboard(QString fileExtension,
 					   std::function<bool(QFile*)> write,

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -12,6 +12,7 @@
 #include <QDesktopServices>
 #include <QMessageBox>
 #include <QTemporaryFile>
+#include <QTemporaryDir>
 
 #include "clip.h"
 #include "r.h"

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -11,6 +11,7 @@
 #include <QTimer>
 #include <QDesktopServices>
 #include <QMessageBox>
+#include <QTemporaryFile>
 
 #include "clip.h"
 #include "r.h"
@@ -47,6 +48,9 @@ private slots:
 	void on_tw_history_cellDoubleClicked(int row, int column);
 	
 	void on_actionExit_triggered();
+	void on_actionEdit_clipboard_as_text_triggered();
+	void on_actionEdit_clipboard_as_color_triggered();
+	void on_actionEdit_clipboard_as_image_triggered();
 	void on_actionAbout_Dragon_s_Drop_triggered();
 	void on_actionAbout_Qt_triggered();
 	

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -13,6 +13,8 @@
 #include <QMessageBox>
 #include <QTemporaryFile>
 #include <QTemporaryDir>
+#include <QFileInfo>
+#include <QColorDialog>
 
 #include "clip.h"
 #include "r.h"
@@ -31,6 +33,8 @@ public:
 	explicit MainWindow(QWidget *parent = nullptr);
 	~MainWindow();
 	
+	void editClipboard(QString fileExtension, std::function<bool(QFile*)> write, std::function<bool(QFile*)> read);
+	
 private slots:
 	void addHistoryRow(QTableWidgetItem* k, QTableWidgetItem* v);
 	void addHistoryRow(QTableWidgetItem* v);
@@ -39,7 +43,7 @@ private slots:
 	void addHistoryRow(QColor value);
 	void addHistoryRow(QImage value);
 	
-	void onDataChanged(const QMimeData*data);
+	void onDataChanged(const QMimeData*);
 	void onTextReceived(QString text);
 	void onHtmlReceived(QString html);
 	void onUrlsReceived(QList<QUrl> urls);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -33,14 +33,71 @@ public:
 	explicit MainWindow(QWidget *parent = nullptr);
 	~MainWindow();
 	
+	void showEvent(QShowEvent*);
+	
+	/**
+	 * Edit the clipboard content by creating a temporary file containing the clipboard data,
+	 * open the default application associated with the given file extension, and then load
+	 * again the file and apply the data to the clipboard.
+	 * 
+	 * This is an example of the method call using lambda functions:
+	 * @code{.cpp}
+	 * editClipboard(".txt",
+	 * 	[this](QFile* f) {
+	 * 		// Write
+	 * 		f->write(clip->getText().toUtf8());
+	 * 		return true;
+	 * 	},
+	 * 	[this](QFile* f) {
+	 * 		// Read
+	 * 		clip->setText(f->readAll());
+	 * 		return true;
+	 * 	}
+	 * );
+	 * @endcode
+	 * @param fileExtension The file extension that can open the corresponding application.
+	 * @param write Function that write the clipboard content in the given `QFile`. This file object is already instanciated and open. Please do not close the file inside this function. Returns `true` by default, `false` if there is an exception and the method `editClipboard()` must stop right after the execution of `write()`.
+	 * @param read Function that read the given `QFile` content to the clipboard. This file object is already instanciated and open. Please do not close the file inside this function. Returns `true` by default, `false` if there is an exception and the method `editClipboard()` must stop right after the execution of `write()`.
+	 */
 	void editClipboard(QString fileExtension, std::function<bool(QFile*)> write, std::function<bool(QFile*)> read);
 	
 private slots:
+	/**
+	 * Add a row in the history table (the central widget in `MainWindow`)
+	 * @param k The first widget item in the row. It is considered as the "key" cell.
+	 * @param v The second widget item in the row. It is considered as the "value" cell.
+	 */
 	void addHistoryRow(QTableWidgetItem* k, QTableWidgetItem* v);
+	/**
+	 * Add a row in the history table (the central widget in `MainWindow`). The first cell is
+	 * automatically added, with the current date and time as text.
+	 * @param v The second widget item in the row. It is considered as the "value" cell.
+	 */
 	void addHistoryRow(QTableWidgetItem* v);
+	/**
+	 * Add a row in the history table (the central widget in `MainWindow`). The first cell is
+	 * automatically added, with the current date and time as text.
+	 * @param value The value as a string in the second cell.
+	 */
 	void addHistoryRow(QString value);
+	/**
+	 * Add a row in the history table (the central widget in `MainWindow`). The first cell is
+	 * automatically added, with the current date and time as text.
+	 * @param value The value as an URL in the second cell.
+	 */
 	void addHistoryRow(QUrl value);
+	/**
+	 * Add a row in the history table (the central widget in `MainWindow`). The first cell is
+	 * automatically added, with the current date and time as text.
+	 * @param value The value as a color in the second cell. The background color of the cell
+	 * becomes the actual color \p value and the the foreground color is automatically changed.
+	 */
 	void addHistoryRow(QColor value);
+	/**
+	 * Add a row in the history table (the central widget in `MainWindow`). The first cell is
+	 * automatically added, with the current date and time as text.
+	 * @param value The value as an image in the second cell. It is resized to fit in the cell.
+	 */
 	void addHistoryRow(QImage value);
 	
 	void onDataChanged(const QMimeData*);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -15,6 +15,7 @@
 #include <QTemporaryDir>
 #include <QFileInfo>
 #include <QColorDialog>
+#include <QImageWriter>
 
 #include "clip.h"
 #include "r.h"
@@ -59,7 +60,11 @@ public:
 	 * @param write Function that write the clipboard content in the given `QFile`. This file object is already instanciated and open. Please do not close the file inside this function. Returns `true` by default, `false` if there is an exception and the method `editClipboard()` must stop right after the execution of `write()`.
 	 * @param read Function that read the given `QFile` content to the clipboard. This file object is already instanciated and open. Please do not close the file inside this function. Returns `true` by default, `false` if there is an exception and the method `editClipboard()` must stop right after the execution of `write()`.
 	 */
-	void editClipboard(QString fileExtension, std::function<bool(QFile*)> write, std::function<bool(QFile*)> read);
+	void editClipboard(QString fileExtension,
+					   std::function<bool(QFile*)> write,
+					   std::function<bool(QFile*)> read,
+					   QIODevice::OpenMode writeFlags = QIODevice::WriteOnly | QIODevice::Text,
+					   QIODevice::OpenMode readFlags = QIODevice::ReadOnly | QIODevice::Text);
 	
 private slots:
 	/**

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -87,7 +87,6 @@
     </property>
     <addaction name="actionEdit_clipboard_as_text"/>
     <addaction name="actionEdit_clipboard_as_color"/>
-    <addaction name="actionEdit_clipboard_as_HTML"/>
     <addaction name="actionEdit_clipboard_as_image"/>
    </widget>
    <widget class="QMenu" name="menuSync">
@@ -144,11 +143,6 @@
   <action name="actionEdit_clipboard_as_color">
    <property name="text">
     <string>Edit clipboard as color</string>
-   </property>
-  </action>
-  <action name="actionEdit_clipboard_as_HTML">
-   <property name="text">
-    <string>Edit clipboard as HTML</string>
    </property>
   </action>
   <action name="actionEdit_clipboard_as_image">

--- a/r.cpp
+++ b/r.cpp
@@ -1,11 +1,24 @@
 #include "r.h"
 
-QImage getDragonsDropIcon() {
-	return QImage(":/img/svg/dragonsdrop");
+QString R::getTemporaryFileTemplate(QString suffix) {
+	QString dir = QDir::tempPath();
+	
+	if (!dir.endsWith("/"))
+		dir += "/";
+	
+	if (!suffix.startsWith("."))
+		suffix = "." + suffix;
+	
+	QString temp = dir + "dragonsdropXXXXXX" + suffix;
+	return temp;
 }
 
-QImage getDragonsDropIcon(int size) {
-	return QImage(":/img/svg/dragonsdrop" + QString::number(size));
+QPixmap R::getDragonsDropIcon() {
+	return getSvg(":/img/svg/dragonsdrop");
+}
+
+QPixmap R::getDragonsDropIcon(int size) {
+	return getSvg(":/img/svg/dragonsdrop" + QString::number(size));
 }
 
 QPixmap R::getSettings(QColor tint) {

--- a/r.cpp
+++ b/r.cpp
@@ -13,6 +13,16 @@ QString R::getTemporaryFileTemplate(QString suffix) {
 	return temp;
 }
 
+QString R::getTemporaryDirTemplate() {
+	QString dir = QDir::tempPath();
+	
+	if (!dir.endsWith("/"))
+		dir += "/";
+	
+	QString temp = dir + "dragonsdropXXXXXX";
+	return temp;
+}
+
 QPixmap R::getDragonsDropIcon() {
 	return getSvg(":/img/svg/dragonsdrop");
 }

--- a/r.h
+++ b/r.h
@@ -10,10 +10,13 @@
 #include <QPainter>
 #include <QIcon>
 #include <QTextStream>
+#include <QDir>
 
 using namespace std;
 
 namespace R {
+	
+	QString getTemporaryFileTemplate(QString suffix = "XXXXXX");
 	
 	QPixmap getDragonsDropIcon();
 	QPixmap getDragonsDropIcon(int size);

--- a/r.h
+++ b/r.h
@@ -17,6 +17,7 @@ using namespace std;
 namespace R {
 	
 	QString getTemporaryFileTemplate(QString suffix = "XXXXXX");
+	QString getTemporaryDirTemplate();
 	
 	QPixmap getDragonsDropIcon();
 	QPixmap getDragonsDropIcon(int size);


### PR DESCRIPTION
* Added system to open clipboard content with another app
	* Added the beginning of the function to edit a text in the clipboard (not finished, but the main system is written). This function can be used as a template.

* Bug with temporary file system
	* The file system does not work  properly, I try to debug it using several methods.

* Fixed file system bug
	* Fixed the file system bug by reseting the carret position in the file (it was at the end after writing the clipboard content)

* Deployed file system strategy
	* Added a generic function `editClipboard()` to implement the temporary file system. It is used for the text and image editor. However, the temporary image file is corrupted, there's an error with that 😠

* Corrupted JPG, clipboard at startup & doxygen  …
	* Tried to resolve the image problem, and I found something interesting: When I save a JPG with a low compression level, I get a non-corrupted image, however, it's very blur and dirty, some pixels are completely crazy...
	* Added the method `Clip::reprocessClipboardContent()` in order to add the actual clipboard content at startup.
	* Added doxygen doc-comments for the most relevant functions.
	* Fixed a potential bug in the temporary file system: The file was not closed during the edit process.

* Fixed image corrupted bug
	* Fixed the image corrupted bug: It was caused by the flags given on the writing and reading process for the temporary file. I gave the flag `QIODevice::Text` whereas it must not be given for images.